### PR TITLE
Don't allow special characters in highlight words

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function filterStopWords (arr) {
 }
 function getTitleWordArray (title) {
   return title.split(' ').filter((word) => {
-    return word.length > 4;
+    return word.length > 4 && /^[a-zA-Z]+$/.test(word);
   });
 }
 function getSearchWord (title) {

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function filterStopWords (arr) {
 }
 function getTitleWordArray (title) {
   return title.split(' ').filter((word) => {
-    return word.length > 4 && /^[a-zA-Z]+$/.test(word);
+    return word.length > 4 && /^[a-zA-Z0-9]+$/.test(word);
   });
 }
 function getSearchWord (title) {


### PR DESCRIPTION
## Why?
-Fixes issue #4 
-Non-alphanumeric characters were sanitized out of search terms meaning the sanitized term wouldn't match the original string

## What?
-Added a regex to filter out words containing non-alphanumeric characters from the possible search terms list